### PR TITLE
Make SplObjectStorage exporting in HHVM match Zend

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -270,9 +270,16 @@ class Exporter
         }
 
         // Some internal classes like SplObjectStorage don't work with the
-        // above (fast) mechanism nor with reflection
+        // above (fast) mechanism nor with reflection in Zend.
         // Format the output similarly to print_r() in this case
         if ($value instanceof \SplObjectStorage) {
+            // However, the fast method does work in HHVM, and exposes the
+            // internal implementation. Hide it again.
+            if (property_exists('\SplObjectStorage', '__storage')) {
+              unset($array['__storage']);
+            } else if (property_exists('\SplObjectStorage', 'storage')) {
+              unset($array['storage']);
+            }
             foreach ($value as $key => $val) {
                 $array[spl_object_hash($val)] = array(
                     'obj' => $val,


### PR DESCRIPTION
SplObjectStorage::$storage is the current method.
HHVM is about to be changed so that it uses $__storage instead to reduce
the chance of a conflict in cases like this:

``` PHP
<?php

$o1 = new stdClass();
$store = new SplObjectStorage;
$store->attach($o1);
$store->storage = 'herpderp';
```

This gets PHPUnit to 100%, but #1 still depends on an array_keys fix for
recursive structures that hasn't reached master yet.
