### PR TITLE
fix SplObjectStorage output in future HHVM releases

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -280,6 +280,9 @@ class Exporter
             } else if (property_exists('\SplObjectStorage', 'storage')) {
               unset($array['storage']);
             }
+            if (property_exists('\SplObjectStorage', '__key')) {
+              unset($array['__key']);
+            }
             foreach ($value as $key => $val) {
                 $array[spl_object_hash($val)] = array(
                     'obj' => $val,


### PR DESCRIPTION
- Objects are stored indexed by hash
- However, when iterating, key() needs to return 0..n instead

So, HHVM's added a variable to keep track of the fake key.
