### PR TITLE
Allow shortenedExport() to use __toString() on objects if defined

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -120,7 +120,7 @@ class Exporter
             return sprintf(
                 '%s Object (%s)',
                 get_class($value),
-                count($this->toArray($value)) > 0 ? '...' : ''
+                method_exists($value, '__toString') ? (string)$value : (count($this->toArray($value)) > 0 ? '...' : '')
             );
         }
 


### PR DESCRIPTION
_This PR implements this and is meant as a starting point for discussion._

Not necessarily the final implementation yet but it would be quite handy to have shortenedExport() not only show ... for object properties if the class in question implements __toString.

I didn't add a test for it yet as I'm not sure where to place the code for the dummy class that would implement __toString()?
