### PR TITLE
Introduce Free2Wait monetization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "sebastian/recursion-context": "^3.0"
+        "sebastian/recursion-context": "^3.0",
+        "free2wait/composer-free2wait": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",
@@ -42,6 +43,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "3.1.x-dev"
+        }
+    },
+    "free2wait": {
+        "to": {
+            "paypal": "your.paypal.to.receive.payouts@example.com"
         }
     }
 }


### PR DESCRIPTION
Please refer to https://github.com/Free2Wait/composer-free2wait .

In short: this PR proposes a way to monetize open-source development of your project.
The idea is similar to how free-to-play works in gamedev industry: "You are free to wait for the package download - but in case if time is money for you, please consider buying non-waiting access to the package - every cent goes to the package developer to incentive the open-source development."

According to packagist statistics of your package https://packagist.org/packages/sebastian/exporter/stats , in theory it could bring to you about 2,380,899 (installs per month) * 0.03 (estimated conversion installs-to-sale) * 5 (price of each non-waiting access per month) = estimated $357,134.85 per month.

Please give me your feedback about the idea: what do you think? Are you interested? Do you have any suggestions? Concerns?

Would be glad to receive any feeedback. Thank you for attention.