### PR TITLE
Update PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "prefer-stable": true,
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "sebastian/recursion-context": "^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "sebastian/recursion-context": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^7.0",
         "ext-mbstring": "*"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          verbose="true">
-    <testsuite>
+    <testsuite name="tests">
         <directory suffix="Test.php">tests</directory>
     </testsuite>
 


### PR DESCRIPTION
This PR updates the required version of PHPUnit and fixes an issue due to PHPUnit 7 (missing required attribute).
Note: this PR drops the compatibility with PHP 7.0, so it is normal that the Travis CI fails on PHP 7.0.