### PR TITLE
Exclude trace from exceptions/errors for performance reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Exception Object &0000000078de0f0d000000002003a261 (
     'code' => 0
     'file' => '/home/sebastianbergmann/test.php'
     'line' => 34
-    'trace' => Array &0 ()
     'previous' => null
 )
 */

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -146,6 +146,13 @@ class Exporter
         $array = [];
 
         foreach ((array) $value as $key => $val) {
+            // Exception traces commonly reference hundreds to thousands of
+            // objects currently loaded in memory. Including them in the result
+            // has a severe negative performance impact.
+            if ("\0Error\0trace" === $key || "\0Exception\0trace" === $key) {
+                continue;
+            }
+
             // properties are transformed to keys in the following way:
             // private   $property => "\0Classname\0property"
             // protected $property => "\0*\0property"

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -168,6 +168,32 @@ EOF
                 '',
                 "''"
             ],
+            'export Exception without trace' => [
+                new \Exception('The exception message', 42),
+                <<<EOF
+Exception Object &%x (
+    'message' => 'The exception message'
+    'string' => ''
+    'code' => 42
+    'file' => '%s/tests/ExporterTest.php'
+    'line' => %d
+    'previous' => null
+)
+EOF
+            ],
+            'export Error without trace' => [
+                new \Error('The exception message', 42),
+                <<<EOF
+Error Object &%x (
+    'message' => 'The exception message'
+    'string' => ''
+    'code' => 42
+    'file' => '%s/tests/ExporterTest.php'
+    'line' => %d
+    'previous' => null
+)
+EOF
+            ],
         ];
     }
 


### PR DESCRIPTION
I'm experiencing severe performance problems in one of my test suites and tracked these down to PhpUnit tests that used Prophecy in combination with exceptions.

When Prophecy compares method calls with arguments, it will turn all of the arguments into an array and compare that array. The reason lies in [ObjectComparator line 70](https://github.com/sebastianbergmann/comparator/blob/master/src/ObjectComparator.php#L70): In the case of method call comparisons, `$actual` (an `ArgumentsWildcard` object created during the call) is never identical to `$expected` (an `ArgumentsWildcard` object created during setting up the expectation).

If one of these arguments is an `Error` or an `Exception`, turning the error/exception into an array can take seconds to minutes (in my current case) due to the contained stack trace since the trace contains references to the entire test suite and most of the objects created during the test suite. In my specific test suite, I have two extreme cases where the following assertion results in **109.935 calls** to `Exporter::toArray()` taking up **26 seconds** each simply due to the stack trace being huge.

```php
$this->sentryClientProphecy->captureException(Argument::cetera())->shouldHaveBeenCalledTimes(5);
```

I don't see a benefit in including the stack trace in the comparison as the stack trace contains no information generated by the developer and hence no informatoin relevant to a test.