### PR TITLE
Fix email address in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         },
         {
             "name": "Bernhard Schussek",
-            "email": "bschussek@2bepublished.at"
+            "email": "bschussek@gmail.com"
         }
     ],
     "config": {


### PR DESCRIPTION
The email address listed in composer.json doesn't exist anymore. I'm switching this to my private email.