### PR TITLE
Fix exception when types are not coherent

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -252,7 +252,7 @@ class Exporter
             "'";
         }
 
-        $whitespace = \str_repeat(' ', 4 * $indentation);
+        $whitespace = \str_repeat(' ', (int) (4 * $indentation));
 
         if (!$processed) {
             $processed = new Context;


### PR DESCRIPTION
I got this exception:

`Uncaught TypeError: str_repeat() expects parameter 2 to be integer, float given in /Users/loevgaard/PhpstormProjects/SyliusStockMovementPlugin/vendor/sebastian/exporter/src/Exporter.php:255`

and fixed it by doing this small change.