### PR TITLE
Remove unsupported HHVM code

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -173,18 +173,6 @@ class Exporter
         // above (fast) mechanism nor with reflection in Zend.
         // Format the output similarly to print_r() in this case
         if ($value instanceof \SplObjectStorage) {
-            // However, the fast method does work in HHVM, and exposes the
-            // internal implementation. Hide it again.
-            if (\property_exists('\SplObjectStorage', '__storage')) {
-                unset($array['__storage']);
-            } elseif (\property_exists('\SplObjectStorage', 'storage')) {
-                unset($array['storage']);
-            }
-
-            if (\property_exists('\SplObjectStorage', '__key')) {
-                unset($array['__key']);
-            }
-
             foreach ($value as $key => $val) {
                 $array[\spl_object_hash($val)] = [
                     'obj' => $val,


### PR DESCRIPTION
I found some code that is still from the time where HHVM was supported. This PR removes the now unused code from the Exporter.