### PR TITLE
Increase codecoverage

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -47,8 +47,8 @@ class Exporter
     }
 
     /**
-     * @param mixed   $data
-     * @param Context $context
+     * @param array<mixed> $data
+     * @param Context      $context
      *
      * @return string
      */


### PR DESCRIPTION
This PR is about increasing the code coverage for this repository.

There are two places with LoC I didn't cover:

### The case where mbstring isn't installed in PHP

I don't know a way (without a third party lib) to test a case without mbstring installed. Do you have any suggestions if this should be tested and how?

### The case where a string `*RECURSION* ` is created

I covered this case in a separate test, but I wasn't able to cover this path in `testShortenedRecursiveExport()`.

----

I also think that the type of the `$data` argument of `shortenedRecursiveExport` has to be `array`, because `$context->add($data);` expects an array or an object, while the loop there is an array accessor `$data[$key]` that suggests that `$data` has to be array or ArrayAccess. Because of a previous `is_array` check, ArrayAccess can't be available here.