### PR TITLE
Improve export of closed resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
 
 name: "CI"
 
+env:
+  # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
+  COMPOSER_ROOT_VERSION: '4.99.99'
+
 jobs:
   coding-guidelines:
     name: "Coding Guidelines"

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -14,6 +14,7 @@ use function count;
 use function function_exists;
 use function get_class;
 use function get_resource_type;
+use function gettype;
 use function implode;
 use function is_array;
 use function is_float;
@@ -233,6 +234,10 @@ class Exporter
 
         if (is_float($value) && (float) ((int) $value) === $value) {
             return "{$value}.0";
+        }
+
+        if (gettype($value) === 'resource (closed)') {
+            return 'resource (closed)';
         }
 
         if (is_resource($value)) {

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -11,6 +11,7 @@ namespace SebastianBergmann\Exporter;
 
 use function array_map;
 use function chr;
+use function fclose;
 use function fopen;
 use function implode;
 use function mb_internal_encoding;
@@ -64,6 +65,9 @@ class ExporterTest extends TestCase
         $storage->attach($obj2);
         $storage->foo = $obj2;
 
+        $resource = fopen('php://memory', 'r');
+        fclose($resource);
+
         return [
             'export null'                   => [null, 'null'],
             'export boolean true'           => [true, 'true'],
@@ -72,6 +76,7 @@ class ExporterTest extends TestCase
             'export float 1.0'              => [1.0, '1.0'],
             'export float 1.2'              => [1.2, '1.2'],
             'export stream'                 => [fopen('php://memory', 'r'), 'resource(%d) of type (stream)'],
+            'export stream (closed)'        => [$resource, 'resource (closed)'],
             'export numeric string'         => ['1', "'1'"],
             'export multidimentional array' => [[[1, 2, 3], [3, 4, 5]],
                 <<<'EOF'


### PR DESCRIPTION
Fixes #36

If you're so inclined, a backport to the 4.x branch would be great! ❤️ 

Note: I've added a second commit to fix the CI, which [was failing on the `composer install` with the recursive dependency](https://github.com/jrfnl/exporter/actions/runs/1446816539). The fix as now included should work during the whole of the `5.x` dev cycle and will need adjusting when work starts on the next major (after 5.x).
