### PR TITLE
Improve export of closed resources (for 3.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 before_install:
+  # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
+  - export COMPOSER_ROOT_VERSION="3.99.99"
   - composer self-update
   - composer clear-cache
 

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -52,6 +52,9 @@ class ExporterTest extends TestCase
         $storage->attach($obj2);
         $storage->foo = $obj2;
 
+        $resource = \fopen('php://memory', 'r');
+        \fclose($resource);
+
         return [
             'export null'                   => [null, 'null'],
             'export boolean true'           => [true, 'true'],
@@ -60,6 +63,7 @@ class ExporterTest extends TestCase
             'export float 1.0'              => [1.0, '1.0'],
             'export float 1.2'              => [1.2, '1.2'],
             'export stream'                 => [\fopen('php://memory', 'r'), 'resource(%d) of type (stream)'],
+            'export stream (closed)'        => [$resource, 'resource (closed)'],
             'export numeric string'         => ['1', "'1'"],
             'export multidimentional array' => [[[1, 2, 3], [3, 4, 5]],
                 <<<EOF


### PR DESCRIPTION
As the 3.x branch has a minimum PHP version of PHP 7.0 and the `resource (closed)` return value for `gettype()` was only introduced in PHP 7.2, a slightly more involved solution for the same is needed for the 3.x branch.

The methods I'm adding are based on code I've used to polyfill the `assertClosedResource()` assertion in the PHPUnit Polyfills and has been (and still is) extensively tested there.

Fixes #36 for 3.x