### PR TITLE
Proposal: Change `Object &hash` to `Object #id` in variable representation

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -24,7 +24,7 @@ use function is_string;
 use function mb_strlen;
 use function mb_substr;
 use function preg_match;
-use function spl_object_hash;
+use function spl_object_id;
 use function sprintf;
 use function str_repeat;
 use function str_replace;
@@ -181,7 +181,7 @@ final class Exporter
         // Format the output similarly to print_r() in this case
         if ($value instanceof SplObjectStorage) {
             foreach ($value as $_value) {
-                $array[spl_object_hash($_value)] = [
+                $array['Object #' . spl_object_id($_value)] = [
                     'obj' => $_value,
                     'inf' => $value->getInfo(),
                 ];
@@ -277,11 +277,11 @@ final class Exporter
         if (is_object($value)) {
             $class = get_class($value);
 
-            if ($hash = $processed->contains($value)) {
-                return sprintf('%s Object &%s', $class, $hash);
+            if ($processed->contains($value)) {
+                return sprintf('%s Object #%d', $class, spl_object_id($value));
             }
 
-            $hash   = $processed->add($value);
+            $processed->add($value);
             $values = '';
             $array  = $this->toArray($value);
 
@@ -298,7 +298,7 @@ final class Exporter
                 $values = "\n" . $values . $whitespace;
             }
 
-            return sprintf('%s Object &%s (%s)', $class, $hash, $values);
+            return sprintf('%s Object #%d (%s)', $class, spl_object_id($value), $values);
         }
 
         return var_export($value, true);

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -107,10 +107,10 @@ long\n\r
 text'
 EOF
             ],
-            'export empty stdclass'     => [new stdClass, 'stdClass Object &%x ()'],
+            'export empty stdclass'     => [new stdClass, 'stdClass Object #%d ()'],
             'export non empty stdclass' => [$obj,
                 <<<'EOF'
-stdClass Object &%x (
+stdClass Object #%d (
     'null' => null
     'boolean' => true
     'integer' => 1
@@ -127,26 +127,26 @@ very\n
 very\r
 long\n\r
 text'
-    'object' => stdClass Object &%x (
+    'object' => stdClass Object #%d (
         'foo' => 'bar'
     )
-    'objectagain' => stdClass Object &%x
+    'objectagain' => stdClass Object #%d
     'array' => Array &%d (
         'foo' => 'bar'
     )
-    'self' => stdClass Object &%x
+    'self' => stdClass Object #%d
 )
 EOF
             ],
             'export empty array'      => [[], 'Array &%d ()'],
             'export splObjectStorage' => [$storage,
                 <<<'EOF'
-SplObjectStorage Object &%x (
-    'foo' => stdClass Object &%x (
+SplObjectStorage Object #%d (
+    'foo' => stdClass Object #%d (
         'foo' => 'bar'
     )
-    '%x' => Array &0 (
-        'obj' => stdClass Object &%x
+    'Object #%d' => Array &0 (
+        'obj' => stdClass Object #%d
         'inf' => null
     )
 )
@@ -154,7 +154,7 @@ EOF
             ],
             'export stdClass with numeric properties' => [$obj3,
                 <<<'EOF'
-stdClass Object &%x (
+stdClass Object #%d (
     0 => 1
     1 => 2
     2 => 'Test\r\n
@@ -186,7 +186,7 @@ EOF
             'export Exception without trace' => [
                 new Exception('The exception message', 42),
                 <<<'EOF'
-Exception Object &%x (
+Exception Object #%d (
     'message' => 'The exception message'
     'string' => ''
     'code' => 42
@@ -199,7 +199,7 @@ EOF
             'export Error without trace' => [
                 new Error('The exception message', 42),
                 <<<'EOF'
-Error Object &%x (
+Error Object #%d (
     'message' => 'The exception message'
     'string' => ''
     'code' => 42
@@ -262,10 +262,10 @@ very\n
 very\r
 long\n\r
 text'
-    'object' => stdClass Object &%x (
+    'object' => stdClass Object #%d (
         'foo' => 'bar'
     )
-    'objectagain' => stdClass Object &%x
+    'objectagain' => stdClass Object #%d
     'array' => Array &%d (
         'foo' => 'bar'
     )
@@ -287,8 +287,8 @@ very\n
 very\r
 long\n\r
 text'
-        'object' => stdClass Object &%x
-        'objectagain' => stdClass Object &%x
+        'object' => stdClass Object #%d
+        'objectagain' => stdClass Object #%d
         'array' => Array &%d (
             'foo' => 'bar'
         )


### PR DESCRIPTION
This proposes using `#` instead of `&` to

1. Avoid overlapping with the hash numbers for `Array &%d ()`
2. Be similar to var_dump.

This proposes a `Object #` prefix for SplObjectStorage object id keys
to make **accidental** ambiguity with dynamic properties less likely.

Closes #39