### PR TITLE
Improve export of enums

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -11,5 +11,9 @@
       <code>$hash</code>
       <code>$key</code>
     </InvalidScalarArgument>
+    <NoInterfaceProperties occurrences="6">
+      <code>$value->name</code>
+      <code>$value->value</code>
+    </NoInterfaceProperties>
   </file>
 </files>

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,11 @@
             "src/"
         ]
     },
+    "autoload-dev": {
+        "classmap": [
+            "tests/"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "5.0-dev"

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -15,6 +15,7 @@ use function get_class;
 use function get_resource_type;
 use function gettype;
 use function implode;
+use function interface_exists;
 use function is_array;
 use function is_float;
 use function is_object;
@@ -28,8 +29,10 @@ use function sprintf;
 use function str_repeat;
 use function str_replace;
 use function var_export;
+use BackedEnum;
 use SebastianBergmann\RecursionContext\Context;
 use SplObjectStorage;
+use UnitEnum;
 
 /**
  * A nifty utility for visualizing PHP variables.
@@ -113,6 +116,26 @@ final class Exporter
             }
 
             return $string;
+        }
+
+        // FIXME: Remove 'interface_exists' check once we drop support for PHP 8.0
+        if (interface_exists('\UnitEnum')) {
+            if ($value instanceof BackedEnum) {
+                return sprintf(
+                    '%s Enum (%s, %s)',
+                    get_class($value),
+                    $value->name,
+                    $this->export($value->value)
+                );
+            }
+
+            if ($value instanceof UnitEnum) {
+                return sprintf(
+                    '%s Enum (%s)',
+                    get_class($value),
+                    $value->name
+                );
+            }
         }
 
         if (is_object($value)) {
@@ -215,6 +238,28 @@ final class Exporter
                 $value,
                 get_resource_type($value)
             );
+        }
+
+        // FIXME: Remove 'interface_exists' check once we drop support for PHP 8.0
+        if (interface_exists('\UnitEnum')) {
+            if ($value instanceof BackedEnum) {
+                return sprintf(
+                    '%s Enum #%d (%s, %s)',
+                    get_class($value),
+                    spl_object_id($value),
+                    $value->name,
+                    $this->export($value->value, $indentation)
+                );
+            }
+
+            if ($value instanceof UnitEnum) {
+                return sprintf(
+                    '%s Enum #%d (%s)',
+                    get_class($value),
+                    spl_object_id($value),
+                    $value->name
+                );
+            }
         }
 
         if (is_string($value)) {

--- a/tests/ExampleEnum.php
+++ b/tests/ExampleEnum.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/exporter.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Exporter;
+
+/*
+ * Helper to test export of enums.
+ */
+enum ExampleEnum
+{
+    case Value;
+}

--- a/tests/ExampleIntegerBackedEnum.php
+++ b/tests/ExampleIntegerBackedEnum.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/exporter.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Exporter;
+
+/*
+ * Helper to test export of backed enums.
+ */
+enum ExampleIntegerBackedEnum: int
+{
+    case Value = 0;
+}

--- a/tests/ExampleStringBackedEnum.php
+++ b/tests/ExampleStringBackedEnum.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/exporter.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Exporter;
+
+/*
+ * Helper to test export of backed enums.
+ */
+enum ExampleStringBackedEnum: string
+{
+    case Value = 'value';
+}

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -370,7 +370,7 @@ EOF;
         return [
             'export enum'                          => [ExampleEnum::Value, 'SebastianBergmann\Exporter\ExampleEnum Enum #%d (Value)'],
             'export backed enum'                   => [ExampleStringBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleStringBackedEnum Enum #%d (Value, \'value\')'],
-            'shortened export integer backed enum' => [ExampleIntegerBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleIntegerBackedEnum Enum #%d (Value, 0)'],
+            'export integer backed enum' => [ExampleIntegerBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleIntegerBackedEnum Enum #%d (Value, 0)'],
         ];
     }
 

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -365,6 +365,50 @@ EOF;
         mb_language($oldMbLanguage);
     }
 
+    public function enumProvider()
+    {
+        return [
+            'export enum'                          => [ExampleEnum::Value, 'SebastianBergmann\Exporter\ExampleEnum Enum #%d (Value)'],
+            'export backed enum'                   => [ExampleStringBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleStringBackedEnum Enum #%d (Value, \'value\')'],
+            'shortened export integer backed enum' => [ExampleIntegerBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleIntegerBackedEnum Enum #%d (Value, 0)'],
+        ];
+    }
+
+    /**
+     * @requires PHP 8.1
+     * @dataProvider enumProvider
+     */
+    public function testEnumExport($value, $expected): void
+    {
+        // FIXME: Merge test into testExport once we drop support for PHP 8.0
+        $this->assertStringMatchesFormat(
+            $expected,
+            $this->trimNewline($this->exporter->export($value))
+        );
+    }
+
+    public function enumShortenedProvider()
+    {
+        return [
+            'shortened export enum'                => [ExampleEnum::Value, 'SebastianBergmann\Exporter\ExampleEnum Enum (Value)'],
+            'shortened export string backed enum'  => [ExampleStringBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleStringBackedEnum Enum (Value, \'value\')'],
+            'shortened export integer backed enum' => [ExampleIntegerBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleIntegerBackedEnum Enum (Value, 0)'],
+        ];
+    }
+
+    /**
+     * @requires PHP 8.1
+     * @dataProvider enumShortenedProvider
+     */
+    public function testEnumShortenedExport($value, $expected): void
+    {
+        // FIXME: Merge test into testShortenedExport once we drop support for PHP 8.0
+        $this->assertStringMatchesFormat(
+            $expected,
+            $this->trimNewline($this->exporter->shortenedExport($value))
+        );
+    }
+
     public function provideNonBinaryMultibyteStrings(): array
     {
         return [

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -365,47 +365,75 @@ EOF;
         mb_language($oldMbLanguage);
     }
 
-    public function enumProvider()
-    {
-        return [
-            'export enum'                          => [ExampleEnum::Value, 'SebastianBergmann\Exporter\ExampleEnum Enum #%d (Value)'],
-            'export backed enum'                   => [ExampleStringBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleStringBackedEnum Enum #%d (Value, \'value\')'],
-            'export integer backed enum' => [ExampleIntegerBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleIntegerBackedEnum Enum #%d (Value, 0)'],
-        ];
-    }
-
     /**
      * @requires PHP 8.1
-     * @dataProvider enumProvider
      */
-    public function testEnumExport($value, $expected): void
+    public function testEnumExport(): void
     {
         // FIXME: Merge test into testExport once we drop support for PHP 8.0
         $this->assertStringMatchesFormat(
-            $expected,
-            $this->trimNewline($this->exporter->export($value))
+            'SebastianBergmann\Exporter\ExampleEnum Enum #%d (Value)',
+            $this->trimNewline($this->exporter->export(ExampleEnum::Value))
         );
-    }
-
-    public function enumShortenedProvider()
-    {
-        return [
-            'shortened export enum'                => [ExampleEnum::Value, 'SebastianBergmann\Exporter\ExampleEnum Enum (Value)'],
-            'shortened export string backed enum'  => [ExampleStringBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleStringBackedEnum Enum (Value, \'value\')'],
-            'shortened export integer backed enum' => [ExampleIntegerBackedEnum::Value, 'SebastianBergmann\Exporter\ExampleIntegerBackedEnum Enum (Value, 0)'],
-        ];
     }
 
     /**
      * @requires PHP 8.1
-     * @dataProvider enumShortenedProvider
      */
-    public function testEnumShortenedExport($value, $expected): void
+    public function testStringBackedEnumExport(): void
     {
-        // FIXME: Merge test into testShortenedExport once we drop support for PHP 8.0
+        // FIXME: Merge test into testExport once we drop support for PHP 8.0
         $this->assertStringMatchesFormat(
-            $expected,
-            $this->trimNewline($this->exporter->shortenedExport($value))
+            'SebastianBergmann\Exporter\ExampleStringBackedEnum Enum #%d (Value, \'value\')',
+            $this->trimNewline($this->exporter->export(ExampleStringBackedEnum::Value))
+        );
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testIntegerBackedEnumExport(): void
+    {
+        // FIXME: Merge test into testExport once we drop support for PHP 8.0
+        $this->assertStringMatchesFormat(
+            'SebastianBergmann\Exporter\ExampleIntegerBackedEnum Enum #%d (Value, 0)',
+            $this->trimNewline($this->exporter->export(ExampleIntegerBackedEnum::Value))
+        );
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testEnumShortenedExport(): void
+    {
+        // FIXME: Merge test into testExport once we drop support for PHP 8.0
+        $this->assertStringMatchesFormat(
+            'SebastianBergmann\Exporter\ExampleEnum Enum (Value)',
+            $this->trimNewline($this->exporter->shortenedExport(ExampleEnum::Value))
+        );
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testStringBackedEnumShortenedExport(): void
+    {
+        // FIXME: Merge test into testExport once we drop support for PHP 8.0
+        $this->assertStringMatchesFormat(
+            'SebastianBergmann\Exporter\ExampleStringBackedEnum Enum (Value, \'value\')',
+            $this->trimNewline($this->exporter->shortenedExport(ExampleStringBackedEnum::Value))
+        );
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testIntegerBackedEnumShortenedExport(): void
+    {
+        // FIXME: Merge test into testExport once we drop support for PHP 8.0
+        $this->assertStringMatchesFormat(
+            'SebastianBergmann\Exporter\ExampleIntegerBackedEnum Enum (Value, 0)',
+            $this->trimNewline($this->exporter->shortenedExport(ExampleIntegerBackedEnum::Value))
         );
     }
 


### PR DESCRIPTION
This pull request improves the export of enumerations (see https://wiki.php.net/rfc/enumerations). This change is backwards-compatible with PHP 8.0, however some of the code should probably be refactored once support for PHP 8.0 is dropped. 

Previously, enums would be exported as objects (which they are internally), like so:

```php
SebastianBergmann\Exporter\ExampleEnum Object #%d (
    'name' => 'Value'
)
```

This commit changes that behaviour and improves the export for both backed and non-backed enums:

**Unit enum:** 

```php
SebastianBergmann\Exporter\ExampleEnum Enum #%d (Value)
```

**Backed enum:** 

```php
SebastianBergmann\Exporter\ExampleStringBackedEnum Enum #%d (Value, 'value')
```