### PR TITLE
Fix: Export `COMPOSER_ROOT_VERSION` environment variable in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 name: "CI"
 
+env:
+  COMPOSER_ROOT_VERSION: "5.0-dev"
+
 jobs:
   coding-guidelines:
     name: "Coding Guidelines"


### PR DESCRIPTION
This pull request

- [x] exports `COMPOSER_ROOT_VERSION` as environment variable in the workflow

Related to https://github.com/sebastianbergmann/exporter/pull/42#issuecomment-1014337269.