### PR TITLE
Optimize export of large arrays and object graphs

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -291,25 +291,26 @@ final class Exporter
 
             if (count($array) > 0) {
                 foreach ($array as $k => $v) {
-                    $values .= sprintf(
-                        '%s    %s => %s,' . "\n",
-                        $whitespace,
-                        $this->recursiveExport($k, $indentation),
-                        $this->recursiveExport($value[$k], $indentation + 1, $processed),
-                    );
+                    $values .=
+                        $whitespace
+                        . '    ' .
+                        $this->recursiveExport($k, $indentation)
+                        . ' => ' .
+                        $this->recursiveExport($value[$k], $indentation + 1, $processed)
+                        . ",\n";
                 }
 
                 $values = "\n" . $values . $whitespace;
             }
 
-            return sprintf('Array &%s [%s]', $key, $values);
+            return 'Array &' . (string) $key . ' [' . $values . ']';
         }
 
         if (is_object($value)) {
             $class = $value::class;
 
             if ($processed->contains($value)) {
-                return sprintf('%s Object #%d', $class, spl_object_id($value));
+                return $class . ' Object #' . spl_object_id($value);
             }
 
             $processed->add($value);
@@ -318,18 +319,19 @@ final class Exporter
 
             if (count($array) > 0) {
                 foreach ($array as $k => $v) {
-                    $values .= sprintf(
-                        '%s    %s => %s' . ",\n",
-                        $whitespace,
-                        $this->recursiveExport($k, $indentation),
-                        $this->recursiveExport($v, $indentation + 1, $processed),
-                    );
+                    $values .=
+                        $whitespace
+                        . '    ' .
+                        $this->recursiveExport($k, $indentation)
+                        . ' => ' .
+                        $this->recursiveExport($v, $indentation + 1, $processed)
+                        . ",\n";
                 }
 
                 $values = "\n" . $values . $whitespace;
             }
 
-            return sprintf('%s Object #%d (%s)', $class, spl_object_id($value), $values);
+            return $class . ' Object #' . spl_object_id($value) . ' (' . $values . ')';
         }
 
         return var_export($value, true);


### PR DESCRIPTION
get rid of `sprintf` saves a lot of memory

before this PR
```
➜  memopt git:(main) ✗ php vendor/bin/phpunit --no-results

PHPUnit 10.3.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.10
Configuration: /Users/staabm/workspace/memopt/phpunit.xml.dist

....FFF.............FFFFFFFFFF                                    30 / 30 (100%)

Time: 00:02.630, Memory: 622.16 MB
```

after this PR
```
➜  memopt git:(main) ✗ php vendor/bin/phpunit --no-results

PHPUnit 10.3.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.10
Configuration: /Users/staabm/workspace/memopt/phpunit.xml.dist

....FFF.............FFFFFFFFFF                                    30 / 30 (100%)

Time: 00:02.530, Memory: 522.62 MB
```

=> ~ 17% memory saving

tested on a https://github.com/gnutix/phpstan-typeinferencetest-memory-exhausted with a few dataproviders removed (as the initial example was too massive to profile)

initial discussion in https://github.com/phpstan/phpstan/discussions/9914