### PR TITLE
Make the export customizable

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -34,7 +34,7 @@ use SebastianBergmann\RecursionContext\Context;
 use SplObjectStorage;
 use UnitEnum;
 
-final class Exporter
+final class Exporter implements ExporterInterface
 {
     /**
      * Exports a value as a string.

--- a/src/ExporterInterface.php
+++ b/src/ExporterInterface.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/exporter.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Exporter;
+
+use SebastianBergmann\RecursionContext\Context;
+
+interface ExporterInterface
+{
+    /**
+     * Exports a value as a string.
+     *
+     * The output of this method is similar to the output of print_r(), but
+     * improved in various aspects:
+     *
+     *  - NULL is rendered as "null" (instead of "")
+     *  - TRUE is rendered as "true" (instead of "1")
+     *  - FALSE is rendered as "false" (instead of "")
+     *  - Strings are always quoted with single quotes
+     *  - Carriage returns and newlines are normalized to \n
+     *  - Recursion and repeated rendering is treated properly
+     */
+    public function export(mixed $value, int $indentation = 0): string;
+
+    public function shortenedRecursiveExport(array &$data, Context $context = null): string;
+
+    /**
+     * Exports a value into a single-line string.
+     *
+     * The output of this method is similar to the output of
+     * SebastianBergmann\Exporter\Exporter::export().
+     *
+     * Newlines are replaced by the visible string '\n'.
+     * Contents of arrays and objects (if any) are replaced by '...'.
+     */
+    public function shortenedExport(mixed $value): string;
+
+    /**
+     * Converts an object to an array containing all of its private, protected
+     * and public properties.
+     */
+    public function toArray(mixed $value): array;
+
+    /**
+     * Exports nested array items (the "interior" of array or an object
+     * converted to array).
+     */
+    public function exportNestedItems(array $array, int $indentation, Context $processed): string;
+}

--- a/src/SelfExportableInterface.php
+++ b/src/SelfExportableInterface.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/exporter.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Exporter;
+
+use SebastianBergmann\RecursionContext\Context;
+
+interface SelfExportableInterface
+{
+    public function exportSelf(ExporterInterface $exporter, int $indentation, Context $context): string;
+
+    public function shortenedExportSelf(ExporterInterface $exporter, Context $context): string;
+}

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -270,6 +270,45 @@ EOF
         ];
     }
 
+    public static function exportNestedItemsProvider(): array
+    {
+        return [
+            'export empty array'                      => [[], 0, ''],
+            'export empty array non-zero indentation' => [[], 3, ''],
+            'export multidimensional array'           => [[[1, 2, 3], [3, 4, 5]], 0,
+                <<<'EOF'
+
+    0 => Array &0 [
+        0 => 1,
+        1 => 2,
+        2 => 3,
+    ],
+    1 => Array &1 [
+        0 => 3,
+        1 => 4,
+        2 => 5,
+    ],
+EOF
+            ],
+
+            'export multidimensional array non-zero indentation' => [[[1, 2, 3], [3, 4, 5]], 2,
+                <<<'EOF'
+
+            0 => Array &0 [
+                0 => 1,
+                1 => 2,
+                2 => 3,
+            ],
+            1 => Array &1 [
+                0 => 3,
+                1 => 4,
+                2 => 5,
+            ],
+EOF . "\n        ",
+            ],
+        ];
+    }
+
     #[DataProvider('exportProvider')]
     public function testExport($value, $expected): void
     {
@@ -486,6 +525,17 @@ EOF;
         $value = [$recursiveValue];
 
         $this->assertEquals('*RECURSION*', (new Exporter)->shortenedRecursiveExport($value, $context));
+    }
+
+    #[DataProvider('exportNestedItemsProvider')]
+    public function testExportNestedItems(array $array, int $indentation, $expected): void
+    {
+        $context = new Context;
+
+        $this->assertStringMatchesFormat(
+            $expected,
+            $this->trimNewline((new Exporter)->exportNestedItems($array, $indentation, $context)),
+        );
     }
 
     private function trimNewline(string $string): string


### PR DESCRIPTION
Another attempt to make the exports customizable.  Apologies, if it's out of the scope, I don't mean to waste anyone's time. Just need it for my project (general-purpose extra constraints and assertions for PHPUnit - it worked well with PHPUnit 9/Exporter 4, but not it's kinda broken). 

Anyway, the proposed way for customization is by introducing new ``SelfExportableInterface`` and allow objects that implement this interface to export themselves possibly reusing Exporter's methods.