### PR TITLE
Shorten big arrays to speedup phpunit

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -69,10 +69,10 @@ final readonly class Exporter
         $overallCount = count($data, COUNT_RECURSIVE);
         $counter      = 0;
 
-        $export = $this->shortenedCountedRecursiveExport($data, $processed, $overallCount, $counter);
+        $export = $this->shortenedCountedRecursiveExport($data, $processed, $counter);
 
         if ($overallCount > $this->shortenArraysLongerThan) {
-            $export .= sprintf(' ...%d more elements', $overallCount - $this->shortenArraysLongerThan);
+            $export .= sprintf(', ...%d more elements', $overallCount - $this->shortenArraysLongerThan);
         }
 
         return $export;
@@ -189,7 +189,7 @@ final readonly class Exporter
         return $array;
     }
 
-    private function shortenedCountedRecursiveExport(array &$data, RecursionContext $processed, int $overallCount, int &$counter): string
+    private function shortenedCountedRecursiveExport(array &$data, RecursionContext $processed, int &$counter): string
     {
         $result = [];
 
@@ -199,7 +199,7 @@ final readonly class Exporter
         $processed->add($data);
 
         foreach ($array as $key => $value) {
-            if ($overallCount > $this->shortenArraysLongerThan && $counter > $this->shortenArraysLongerThan) {
+            if ($counter > $this->shortenArraysLongerThan) {
                 break;
             }
 
@@ -207,7 +207,7 @@ final readonly class Exporter
                 if ($processed->contains($data[$key]) !== false) {
                     $result[] = '*RECURSION*';
                 } else {
-                    $result[] = '[' . $this->shortenedCountedRecursiveExport($data[$key], $processed, $overallCount, $counter) . ']';
+                    $result[] = '[' . $this->shortenedCountedRecursiveExport($data[$key], $processed, $counter) . ']';
                 }
             } else {
                 $result[] = $this->shortenedExport($value);

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -69,7 +69,14 @@ final readonly class Exporter
         /* @noinspection UnusedFunctionResultInspection */
         $processed->add($data);
 
+        $i = 0;
+        $count = count($data, COUNT_RECURSIVE);
         foreach ($array as $key => $value) {
+            if ($count > 10 && $i > 10) {
+                $result[] = sprintf('...%d more elements', $count - 10);
+                break;
+            }
+
             if (is_array($value)) {
                 if ($processed->contains($data[$key]) !== false) {
                     $result[] = '*RECURSION*';
@@ -79,6 +86,8 @@ final readonly class Exporter
             } else {
                 $result[] = $this->shortenedExport($value);
             }
+
+            $i++;
         }
 
         return implode(', ', $result);

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -76,7 +76,7 @@ final readonly class Exporter
 
         foreach ($array as $key => $value) {
             if ($count > self::MAX_SHORTENED_ITEMS && $i > self::MAX_SHORTENED_ITEMS) {
-                $result[] = sprintf('...%d more elements', $count - 10);
+                $result[] = sprintf('...%d more elements', $count - self::MAX_SHORTENED_ITEMS);
 
                 break;
             }

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -69,7 +69,7 @@ final readonly class Exporter
         $overallCount = count($data, COUNT_RECURSIVE);
         $counter      = 0;
 
-        $export = $this->_shortenedRecursiveExport($data, $processed, $overallCount, $counter);
+        $export = $this->shortenedCountedRecursiveExport($data, $processed, $overallCount, $counter);
 
         if ($overallCount > $this->shortenArraysLongerThan) {
             $export .= sprintf(' ...%d more elements', $overallCount - $this->shortenArraysLongerThan);
@@ -189,7 +189,7 @@ final readonly class Exporter
         return $array;
     }
 
-    private function _shortenedRecursiveExport(array &$data, RecursionContext $processed, int $overallCount, int &$counter): string
+    private function shortenedCountedRecursiveExport(array &$data, RecursionContext $processed, int $overallCount, int &$counter): string
     {
         $result = [];
 
@@ -207,7 +207,7 @@ final readonly class Exporter
                 if ($processed->contains($data[$key]) !== false) {
                     $result[] = '*RECURSION*';
                 } else {
-                    $result[] = '[' . $this->_shortenedRecursiveExport($data[$key], $processed, $overallCount, $counter) . ']';
+                    $result[] = '[' . $this->shortenedCountedRecursiveExport($data[$key], $processed, $overallCount, $counter) . ']';
                 }
             } else {
                 $result[] = $this->shortenedExport($value);

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -71,11 +71,13 @@ final readonly class Exporter
         /* @noinspection UnusedFunctionResultInspection */
         $processed->add($data);
 
-        $i = 0;
+        $i     = 0;
         $count = count($data, COUNT_RECURSIVE);
+
         foreach ($array as $key => $value) {
             if ($count > self::MAX_SHORTENED_ITEMS && $i > self::MAX_SHORTENED_ITEMS) {
                 $result[] = sprintf('...%d more elements', $count - 10);
+
                 break;
             }
 

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -38,7 +38,10 @@ use UnitEnum;
 
 final readonly class Exporter
 {
-    private const MAX_SHORTENED_ITEMS = 10;
+    public function __construct(
+        private int $shortenArraysLongerThan = 10
+    ) {
+    }
 
     /**
      * Exports a value as a string.
@@ -75,8 +78,8 @@ final readonly class Exporter
         $count = count($data, COUNT_RECURSIVE);
 
         foreach ($array as $key => $value) {
-            if ($count > self::MAX_SHORTENED_ITEMS && $i > self::MAX_SHORTENED_ITEMS) {
-                $result[] = sprintf('...%d more elements', $count - self::MAX_SHORTENED_ITEMS);
+            if ($count > $this->shortenArraysLongerThan && $i > $this->shortenArraysLongerThan) {
+                $result[] = sprintf('...%d more elements', $count - $this->shortenArraysLongerThan);
 
                 break;
             }

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -38,6 +38,8 @@ use UnitEnum;
 
 final readonly class Exporter
 {
+    private const MAX_SHORTENED_ITEMS = 10;
+
     /**
      * Exports a value as a string.
      *
@@ -72,7 +74,7 @@ final readonly class Exporter
         $i = 0;
         $count = count($data, COUNT_RECURSIVE);
         foreach ($array as $key => $value) {
-            if ($count > 10 && $i > 10) {
+            if ($count > self::MAX_SHORTENED_ITEMS && $i > self::MAX_SHORTENED_ITEMS) {
                 $result[] = sprintf('...%d more elements', $count - 10);
                 break;
             }

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -327,6 +327,9 @@ EOF,
             $bigArray[] = 'cast(\'foo' . $i . '\' as blob)';
         }
 
+        $array     = [1, 2, 'hello', 'world', true, false];
+        $deepArray = [$array, [$array, [$array, [$array, [$array, [$array, [$array, [$array, [$array, [$array]]]]]]]]]];
+
         return [
             'null'                   => [[null], 'null'],
             'boolean true'           => [[true], 'true'],
@@ -339,7 +342,8 @@ EOF,
             'with assoc array key'   => [['foo' => 'bar'], '\'bar\''],
             'multidimensional array' => [[[1, 2, 3], [3, 4, 5]], '[1, 2, 3], [3, 4, 5]'],
             'object'                 => [[new stdClass], 'stdClass Object ()'],
-            'big array'              => [$bigArray, "'cast('foo0' as blob)', 'cast('foo1' as blob)', 'cast('foo2' as blob)', 'cast('foo3' as blob)', 'cast('foo4' as blob)', 'cast('foo5' as blob)', 'cast('foo6' as blob)', 'cast('foo7' as blob)', 'cast('foo8' as blob)', 'cast('foo9' as blob)', 'cast('foo10' as blob)', ...19992 more elements"],
+            'big array'              => [$bigArray, "'cast('foo0' as blob)', 'cast('foo1' as blob)', 'cast('foo2' as blob)', 'cast('foo3' as blob)', 'cast('foo4' as blob)', 'cast('foo5' as blob)', 'cast('foo6' as blob)', 'cast('foo7' as blob)', 'cast('foo8' as blob)', 'cast('foo9' as blob)', 'cast('foo10' as blob)' ...19990 more elements"],
+            'deep array'             => [$deepArray, "[1, 2, 'hello', 'world', true, false], [[1, 2, 'hello', 'world']] ...69 more elements"],
         ];
     }
 

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -322,6 +322,7 @@ EOF,
     public static function shortenedRecursiveExportProvider(): array
     {
         $bigArray = [];
+
         for ($i = 0; $i < 20_000; $i++) {
             $bigArray[] = 'cast(\'foo' . $i . '\' as blob)';
         }

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -342,8 +342,8 @@ EOF,
             'with assoc array key'   => [['foo' => 'bar'], '\'bar\''],
             'multidimensional array' => [[[1, 2, 3], [3, 4, 5]], '[1, 2, 3], [3, 4, 5]'],
             'object'                 => [[new stdClass], 'stdClass Object ()'],
-            'big array'              => [$bigArray, "'cast('foo0' as blob)', 'cast('foo1' as blob)', 'cast('foo2' as blob)', 'cast('foo3' as blob)', 'cast('foo4' as blob)', 'cast('foo5' as blob)', 'cast('foo6' as blob)', 'cast('foo7' as blob)', 'cast('foo8' as blob)', 'cast('foo9' as blob)', 'cast('foo10' as blob)' ...19990 more elements"],
-            'deep array'             => [$deepArray, "[1, 2, 'hello', 'world', true, false], [[1, 2, 'hello', 'world']] ...69 more elements"],
+            'big array'              => [$bigArray, "'cast('foo0' as blob)', 'cast('foo1' as blob)', 'cast('foo2' as blob)', 'cast('foo3' as blob)', 'cast('foo4' as blob)', 'cast('foo5' as blob)', 'cast('foo6' as blob)', 'cast('foo7' as blob)', 'cast('foo8' as blob)', 'cast('foo9' as blob)', 'cast('foo10' as blob)', ...19990 more elements"],
+            'deep array'             => [$deepArray, "[1, 2, 'hello', 'world', true, false], [[1, 2, 'hello', 'world']], ...69 more elements"],
         ];
     }
 

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -321,6 +321,11 @@ EOF,
 
     public static function shortenedRecursiveExportProvider(): array
     {
+        $bigArray = [];
+        for ($i = 0; $i < 20_000; $i++) {
+            $bigArray[] = 'cast(\'foo' . $i . '\' as blob)';
+        }
+
         return [
             'null'                   => [[null], 'null'],
             'boolean true'           => [[true], 'true'],
@@ -333,6 +338,7 @@ EOF,
             'with assoc array key'   => [['foo' => 'bar'], '\'bar\''],
             'multidimensional array' => [[[1, 2, 3], [3, 4, 5]], '[1, 2, 3], [3, 4, 5]'],
             'object'                 => [[new stdClass], 'stdClass Object ()'],
+            'big array'              => [$bigArray, "'cast('foo0' as blob)', 'cast('foo1' as blob)', 'cast('foo2' as blob)', 'cast('foo3' as blob)', 'cast('foo4' as blob)', 'cast('foo5' as blob)', 'cast('foo6' as blob)', 'cast('foo7' as blob)', 'cast('foo8' as blob)', 'cast('foo9' as blob)', 'cast('foo10' as blob)', ...19992 more elements"],
         ];
     }
 


### PR DESCRIPTION
goal is to speedup running tests in phpunit with dataproviders with loooots of elements.

----

repro from https://github.com/sebastianbergmann/phpunit/pull/5774#discussion_r1641902563

PHPUnit 10.5.21  on PHP 8.3.8 (on m1 pro)
```
vendor/bin/phpunit tests/TokenizerTest.php 
...
Time: 00:31.553, Memory: 374.09 MB
```

with this PR
```
Time: 00:01.964, Memory: 293.88 MB
```