### PR TITLE
Faster `Exporter->exportString()`

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -30,6 +30,7 @@ use function spl_object_id;
 use function sprintf;
 use function str_repeat;
 use function str_replace;
+use function strtr;
 use function var_export;
 use BackedEnum;
 use ReflectionObject;
@@ -318,14 +319,14 @@ final readonly class Exporter
         }
 
         return "'" .
-            str_replace(
-                '<lf>',
-                "\n",
-                str_replace(
-                    ["\r\n", "\n\r", "\r", "\n"],
-                    ['\r\n<lf>', '\n\r<lf>', '\r<lf>', '\n<lf>'],
-                    $value,
-                ),
+            strtr(
+                $value,
+                [
+                    "\r\n" => '\r\n' . "\n",
+                    "\n\r" => '\n\r' . "\n",
+                    "\r"   => '\r' . "\n",
+                    "\n"   => '\n' . "\n",
+                ],
             ) .
             "'";
     }


### PR DESCRIPTION
remove a unnecessary function call in the hot path.

repro from https://github.com/sebastianbergmann/phpunit/pull/5774#discussion_r1641902563 gets 6% faster

<img width="526" alt="grafik" src="https://github.com/sebastianbergmann/exporter/assets/120441/0f6fc4ad-1847-431d-9087-c4256b3200bb">
