### PR TITLE
Avoid using the Reflection API for some classes

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -33,6 +33,7 @@ use function str_replace;
 use function strtr;
 use function var_export;
 use BackedEnum;
+use Google\Protobuf\Internal\Message;
 use ReflectionObject;
 use SebastianBergmann\RecursionContext\Context as RecursionContext;
 use SplObjectStorage;
@@ -129,7 +130,9 @@ final readonly class Exporter
         }
 
         if (is_object($value)) {
-            $numberOfProperties = count((new ReflectionObject($value))->getProperties());
+            $numberOfProperties = $this->cannotUseReflection($value)
+                ? count($this->toArray($value))
+                : count((new ReflectionObject($value))->getProperties());
 
             return sprintf(
                 '%s Object (%s)',
@@ -392,5 +395,10 @@ final readonly class Exporter
         }
 
         return $class . ' Object #' . spl_object_id($value) . ' (' . $buffer . ')';
+    }
+
+    private function cannotUseReflection(object $object): bool
+    {
+        return $object instanceof Message;
     }
 }


### PR DESCRIPTION
Since sebastian/exporter 6.0.3, my tests started to cause a segfault. I tracked this down to https://github.com/sebastianbergmann/exporter/commit/cb811556a502f1a1c374fdc86f34a7f4a59ba266 which uses Reflection to count an object's properties. Some of my tests use a data provider which contains protobuf messages, and somewhere in phpunit's test setup, it triggers this code on the dataProvider's provided data.

Unfortunately using reflection on some parts of ext-protobuf cause a segfault (which can easily be replicated outside of phpunit). It's a long-standing issue in ext-protobuf, and I think it's a "won't fix".

So, I am hoping that by avoiding reflection only on known bad classes, we can still have the performance benefits without the exploding tests :)