### PR TITLE
fix: use ReflectionClass insteadof ReflectionObject

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -35,9 +35,11 @@ use function strtr;
 use function var_export;
 use BackedEnum;
 use Google\Protobuf\Internal\Message;
+use ReflectionClass;
 use ReflectionObject;
 use SebastianBergmann\RecursionContext\Context as RecursionContext;
 use SplObjectStorage;
+use stdClass;
 use UnitEnum;
 
 final readonly class Exporter
@@ -211,15 +213,18 @@ final readonly class Exporter
 
     public function countProperties(object $value): int
     {
-        if ($this->canBeReflected($value)) {
-            $numberOfProperties = count((new ReflectionObject($value))->getProperties());
-        } else {
+        if (!$this->canBeReflected($value)) {
             // @codeCoverageIgnoreStart
-            $numberOfProperties = count($this->toArray($value));
+            return count($this->toArray($value));
             // @codeCoverageIgnoreEnd
         }
 
-        return $numberOfProperties;
+        if (!$value instanceof stdClass) {
+            // using ReflectionClass prevents initialization of potential lazy objects
+            return count((new ReflectionClass($value))->getProperties());
+        }
+
+        return count((new ReflectionObject($value))->getProperties());
     }
 
     /**

--- a/tests/_fixture/ExampleClass.php
+++ b/tests/_fixture/ExampleClass.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/exporter.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Exporter;
+
+/*
+ * Helper to test export of enums.
+ */
+class ExampleClass
+{
+    private string $foo;
+
+    public function __construct(string $foo)
+    {
+        $this->foo = $foo;
+    }
+}


### PR DESCRIPTION
Reason behind this is that if a dataprovider is passed a php 8.4 lazy proxy, the "lazyness" is lost, because of  `ReflectionObject()->getProperties()`, see https://www.php.net/manual/en/language.oop5.lazy-objects.php#language.oop5.lazy-objects.initialization-triggers