### PR TITLE
Avoid int cast warning when exporting large floats

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -10,8 +10,6 @@
 namespace SebastianBergmann\Exporter;
 
 use const COUNT_RECURSIVE;
-use const PHP_INT_MAX;
-use const PHP_INT_MIN;
 use function assert;
 use function bin2hex;
 use function count;
@@ -35,6 +33,7 @@ use function spl_object_id;
 use function sprintf;
 use function str_repeat;
 use function str_replace;
+use function strpbrk;
 use function strtr;
 use function var_export;
 use BackedEnum;
@@ -368,7 +367,8 @@ final readonly class Exporter
 
         ini_set('precision', $precisionBackup);
 
-        if ($value >= PHP_INT_MIN && $value <= PHP_INT_MAX && (string) (int) $value === $valueAsString) {
+        // Add '.0' only if decimals and scientific notation are absent.
+        if (strpbrk($valueAsString, '.E') === false) {
             return $valueAsString . '.0';
         }
 

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -87,6 +87,7 @@ final class ExporterTest extends TestCase
             'float 1 - 2 / 3'                        => [1 - 2 / 3, '0.33333333333333337', 0],
             'float 5.5E+123'                         => [5.5E+123, '5.5E+123', 0],
             'float 5.5E-123'                         => [5.5E-123, '5.5E-123', 0],
+            'float 9.2233720368547758E+18'           => [9.2233720368547758E+18, '9.223372036854776E+18', 0],
             'float NAN'                              => [NAN, 'NAN', 0],
             'float INF'                              => [INF, 'INF', 0],
             'float -INF'                             => [-INF, '-INF', 0],


### PR DESCRIPTION
resolve https://github.com/sebastianbergmann/phpunit/issues/6589

Large float values used in tests could trigger a runtime warning:

```
stderr: PHP Warning:  The float 9.223372036854776E+18 is not representable as an int, cast occurred in /path/to/project/vendor/sebastian/exporter/src/Exporter.php on line 371
```

This happened because the previous check cast float values to int while deciding whether to append `.0`. Replace that comparison with a simpler string-based check, which avoids the warning and makes the logic easier to follow.