### PR TITLE
Make binary string output readable for mostly-printable values

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -28,11 +28,16 @@ use function is_resource;
 use function is_string;
 use function mb_strlen;
 use function mb_substr;
+use function ord;
 use function preg_match;
+use function preg_match_all;
+use function preg_replace_callback;
 use function spl_object_id;
 use function sprintf;
+use function str_contains;
 use function str_repeat;
 use function str_replace;
+use function strlen;
 use function strpbrk;
 use function strtr;
 use function var_export;
@@ -437,21 +442,44 @@ final readonly class Exporter
     private function exportString(string $value): string
     {
         // Match for most non-printable chars somewhat taking multibyte chars into account
-        if (preg_match('/[^\x09-\x0d\x1b\x20-\xff]/', $value) === 1) {
+        $unprintableCount = preg_match_all('/[^\x09-\x0d\x1b\x20-\xff]/', $value);
+
+        if ($unprintableCount === false || $unprintableCount === 0) {
+            return "'" .
+                strtr(
+                    $value,
+                    [
+                        "\r\n" => '\r\n' . "\n",
+                        "\n\r" => '\n\r' . "\n",
+                        "\r"   => '\r' . "\n",
+                        "\n"   => '\n' . "\n",
+                    ],
+                ) .
+                "'";
+        }
+
+        // A NUL byte or a high ratio of unprintable bytes signals truly
+        // binary data; keep the compact hex dump in those cases.
+        if (str_contains($value, "\x00") || ($unprintableCount / strlen($value)) > 0.3) {
             return 'Binary String: 0x' . bin2hex($value);
         }
 
-        return "'" .
-            strtr(
+        // Mostly printable: keep printable bytes visible and escape only
+        // the offending ones inline using PHP-style \xNN escapes.
+        return 'Binary String: "' .
+            preg_replace_callback(
+                '/[\x00-\x1f\x7f"\\\\]/',
+                static fn (array $m): string => match ($m[0]) {
+                    "\t"    => '\t',
+                    "\n"    => '\n',
+                    "\r"    => '\r',
+                    '"'     => '\"',
+                    '\\'    => '\\\\',
+                    default => sprintf('\x%02x', ord($m[0])),
+                },
                 $value,
-                [
-                    "\r\n" => '\r\n' . "\n",
-                    "\n\r" => '\n\r' . "\n",
-                    "\r"   => '\r' . "\n",
-                    "\n"   => '\n' . "\n",
-                ],
             ) .
-            "'";
+            '"';
     }
 
     /**

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -239,6 +239,26 @@ EOF,
                 'Binary String: 0x0009',
                 0,
             ],
+            'mostly printable string with a single control byte' => [
+                'Hello' . chr(0x01) . 'World',
+                'Binary String: "Hello\x01World"',
+                0,
+            ],
+            'mostly printable string with several control bytes' => [
+                'BEGIN' . chr(0x01) . 'DATA' . chr(0x1F) . 'END',
+                'Binary String: "BEGIN\x01DATA\x1fEND"',
+                0,
+            ],
+            'mixed string with embedded double quote and backslash' => [
+                'a"b\\c' . chr(0x07) . 'd',
+                'Binary String: "a\"b\\\\c\x07d"',
+                0,
+            ],
+            'mixed string preserves UTF-8 high bytes' => [
+                'café' . chr(0x01),
+                'Binary String: "café\x01"',
+                0,
+            ],
             [
                 '',
                 "''",

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -249,6 +249,21 @@ EOF,
                 'Binary String: "BEGIN\x01DATA\x1fEND"',
                 0,
             ],
+            'mostly printable string with embedded tab' => [
+                'Tab' . chr(0x09) . 'Sep' . chr(0x01),
+                'Binary String: "Tab\tSep\x01"',
+                0,
+            ],
+            'mostly printable string with embedded newline' => [
+                'Line1' . chr(0x0A) . 'Line2' . chr(0x01),
+                'Binary String: "Line1\nLine2\x01"',
+                0,
+            ],
+            'mostly printable string with embedded carriage return' => [
+                'A' . chr(0x0D) . 'B' . chr(0x01),
+                'Binary String: "A\rB\x01"',
+                0,
+            ],
             'mixed string with embedded double quote and backslash' => [
                 'a"b\\c' . chr(0x07) . 'd',
                 'Binary String: "a\"b\\\\c\x07d"',


### PR DESCRIPTION
A string that mixes mostly printable text with a few control bytes is currently rendered as a full hex dump, which is hard to read in PHPUnit failure messages. This proposal adds a third rendering form for that case, while leaving the two existing forms untouched for the inputs where they already work well.

### What consumers will see

Three rendering forms, picked automatically based on the input:

1. **Quoted string** (unchanged) for inputs whose bytes are all printable or limited to the existing "safe" control bytes (HT, LF, VT, FF, CR, ESC):

   ```
   'Hello, World'
   ```

2. **Inline-escaped binary string** (new) for inputs that mix mostly printable text with a handful of control bytes:

   ```
   Binary String: "Hello\x01World"
   Binary String: "BEGIN\x01DATA\x1fEND"
   ```

   Printable bytes (including UTF-8 multi-byte characters such as `é`) stay visible. Control bytes are escaped inline using PHP-style `\xNN`. The delimiters `"` and `\` inside the value are escaped too, so the output is unambiguous.

3. **Hex dump** (unchanged form, narrower trigger) for inputs that look truly binary:

   ```
   Binary String: 0x1f8b0800000000000003...
   ```

   This form now triggers only when the input contains a NUL byte (the same heuristic `grep` uses to call a file binary) **or** when more than 30% of its bytes are outside the safe set.

### What does *not* change

- All-printable inputs render exactly as before
- Inputs that are entirely (or almost entirely) control bytes render as the same hex dump as before; the three existing fixtures in `ExporterTest` remain unchanged
- ESC (`\x1b`) is still treated as a safe byte, matching today's behaviour. Switching it to an escaped form would also help readability of strings that carry ANSI sequences, but it would change output for a broader population of existing tests, so it is left out of this change.
